### PR TITLE
Use OpenAI Assistants API with chat thread in sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TanViz (WordPress plugin)
 
-Admin‑only generator of **generative p5.js** visualizations using OpenAI **Responses API** with **JSON Schema**.
+Admin‑only generator of **generative p5.js** visualizations using OpenAI **Assistants API** with **JSON Schema**.
 
 ## Installation
 1. Copy the `TanViz/` folder into `wp-content/plugins/`.
@@ -8,7 +8,7 @@ Admin‑only generator of **generative p5.js** visualizations using OpenAI **Res
 3. Go to **TanViz → Settings** and set:
    - OpenAI API Key.
    - OpenAI Model (default: `gpt-4o-2024-08-06`).
-   - OpenAI Assistant ID (optional).
+   - OpenAI Assistant ID.
    - GitHub Datasets Base (raw URL prefix, e.g. `https://raw.githubusercontent.com/user/repo/branch/path/`).
    - Overlay Logo URL (optional).
 
@@ -17,8 +17,8 @@ Admin‑only generator of **generative p5.js** visualizations using OpenAI **Res
 2. In **TanViz → Sandbox**:
    - Write a prompt describing the visualization.
    - Pick the dataset; a 20‑row sample is shown.
-   - Click **Generate visualization** to call OpenAI.
-   - Inspect/edit the p5.js sketch and **Update preview**.
+   - Click **Generate visualization** to start a chat with OpenAI.
+   - Review the AI code box and copy it into the editor to preview.
    - Provide a Title and Slug then **Save to Library**.
    - Use **Export PNG** or **Export GIF** (experimental, same‑origin canvases only).
    - **Copy iframe** to reuse elsewhere.

--- a/includes/admin-ui.php
+++ b/includes/admin-ui.php
@@ -20,6 +20,7 @@ function tanviz_admin_assets( $hook ){
             'save'     => esc_url_raw( rest_url('TanViz/v1/save') ),
             'fix'      => esc_url_raw( rest_url('TanViz/v1/fix') ),
             'ask'      => esc_url_raw( rest_url('TanViz/v1/ask') ),
+            'chat'     => esc_url_raw( rest_url('TanViz/v1/chat') ),
         ],
         'nonce' => wp_create_nonce('wp_rest'),
         'logo'  => esc_url( get_option('tanviz_logo_url', TANVIZ_URL.'assets/logo.png') ),
@@ -61,8 +62,15 @@ function tanviz_render_sandbox(){
           <h2><?php echo esc_html__('Dataset sample','TanViz'); ?></h2>
           <pre id="tanviz-sample"></pre>
           <p><button class="button button-primary" id="tanviz-generate"><?php echo esc_html__('Generate visualization','TanViz'); ?></button></p>
+          <h2><?php echo esc_html__('Conversation','TanViz'); ?></h2>
+          <div id="tanviz-thread" class="tanviz-thread"></div>
+          <textarea id="tanviz-chat-input" rows="3" class="large-text"></textarea>
+          <p><button class="button" id="tanviz-chat-send"><?php echo esc_html__('Send','TanViz'); ?></button></p>
         </section>
         <section>
+          <h2><?php echo esc_html__('AI Code','TanViz'); ?></h2>
+          <textarea id="tanviz-ai-code" rows="12" class="large-text code"></textarea>
+          <p><button class="button" id="tanviz-copy-ai-code"><?php echo esc_html__('Copy to editor','TanViz'); ?></button></p>
           <h2><?php echo esc_html__('Code (p5.js)','TanViz'); ?></h2>
           <textarea id="tanviz-code" rows="18" class="large-text code"></textarea>
           <p><button class="button" id="tanviz-copy-code"><?php echo esc_html__('Copy code','TanViz'); ?></button>

--- a/includes/openai.php
+++ b/includes/openai.php
@@ -2,101 +2,160 @@
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 /**
- * Calls OpenAI Responses API and extracts p5.js code block.
+ * Interacts with OpenAI Assistants API using thread-based conversations.
  *
- * @param array $args Arguments: dataset_url, prompt_usuario, feedback?, model?
+ * @param array $args Arguments: dataset_url, prompt_usuario, model?, thread_id?
  * @return array
  */
-function tanviz_openai_generate_code_only( array $args ): array {
+function tanviz_openai_assistant_chat( array $args ): array {
     $dataset_url   = isset( $args['dataset_url'] ) ? (string) $args['dataset_url'] : '';
     $prompt_user   = isset( $args['prompt_usuario'] ) ? (string) $args['prompt_usuario'] : '';
-    $feedback      = isset( $args['feedback'] ) && is_array( $args['feedback'] ) ? $args['feedback'] : array();
     $model         = isset( $args['model'] ) ? (string) $args['model'] : 'gpt-4o-2024-08-06';
+    $thread_id     = isset( $args['thread_id'] ) ? (string) $args['thread_id'] : '';
 
-    $fb = array(
-        'root_causes'       => empty( $feedback['root_causes'] ) ? 'Ninguno' : sanitize_textarea_field( implode( '; ', (array) $feedback['root_causes'] ) ),
-        'blocking_errors'   => empty( $feedback['blocking_errors'] ) ? 'Ninguno' : sanitize_textarea_field( implode( '; ', (array) $feedback['blocking_errors'] ) ),
-        'policy_violations' => empty( $feedback['policy_violations'] ) ? 'Ninguno' : sanitize_textarea_field( implode( '; ', (array) $feedback['policy_violations'] ) ),
-        'improvements'      => empty( $feedback['improvements'] ) ? 'Ninguno' : sanitize_textarea_field( implode( '; ', (array) $feedback['improvements'] ) ),
+    $api_key      = trim( get_option( 'tanviz_openai_api_key', '' ) );
+    $assistant_id = trim( get_option( 'tanviz_assistant_id', '' ) );
+    if ( ! $api_key ) {
+        return array( 'ok' => false, 'error' => 'missing_api_key' );
+    }
+    if ( ! $assistant_id ) {
+        return array( 'ok' => false, 'error' => 'missing_assistant_id' );
+    }
+
+    $headers = array(
+        'Authorization' => 'Bearer ' . $api_key,
+        'Content-Type'  => 'application/json',
     );
 
-    $prompt = "Eres un experto en p5.js. Entrega ÚNICAMENTE el archivo final p5.js listo para ejecutar.\n\n" .
-        "ENTRADAS\n" .
-        "- PROMPT DEL USUARIO: {$prompt_user}\n" .
-        "- DATASET_URL: {$dataset_url}\n" .
-        "- Placeholders disponibles: {{col.year}}, {{col.value}} (no hardcodear cabeceras/URLs)\n\n" .
-        "CONTRATO OBLIGATORIO\n" .
-        "1) Estructura: define preload(), setup(), draw(), y windowResized() si procede. Declara helpers antes de usarlos.\n" .
-        "2) Carga de datos: usa SOLO funciones de p5.js (loadTable/loadJSON) con {$dataset_url}.\n" .
-        "3) Placeholders: usa {{col.*}} (p. ej., {{col.year}}, {{col.value}}). Prohibido datos de ejemplo/muestras.\n" .
-        "4) Rangos dinámicos: calcula yearMin/yearMax y min/max de valores.\n" .
-        "5) Prohibido: eval(), import(), fetch(), XHR, CSS externo.\n" .
-        "6) Respuesta: devuelve EXCLUSIVAMENTE el código entre:\n" .
-        "-----BEGIN_P5JS-----\n" .
-        "...AQUÍ VA EL CÓDIGO...\n" .
-        "-----END_P5JS-----\n\n" .
-        "DEFECTOS DETECTADOS EN LA EVALUACIÓN ANTERIOR (CORREGIR OBLIGATORIO)\n" .
-        "- Causas raíz: {$fb['root_causes']}\n" .
-        "- Errores bloqueantes: {$fb['blocking_errors']}\n" .
-        "- Violaciones de contrato: {$fb['policy_violations']}\n" .
-        "- Mejoras solicitadas: {$fb['improvements']}\n";
+    if ( ! $thread_id ) {
+        $resp = wp_remote_post( 'https://api.openai.com/v1/threads', array(
+            'headers' => $headers,
+            'timeout' => 60,
+            'body'    => '{}',
+        ) );
+        if ( is_wp_error( $resp ) ) {
+            tanviz_log_error( 'OpenAI thread create failed: ' . $resp->get_error_message() );
+            return array( 'ok' => false, 'error' => $resp->get_error_message(), 'raw' => '' );
+        }
+        $json      = json_decode( wp_remote_retrieve_body( $resp ), true );
+        $thread_id = $json['id'] ?? '';
+        if ( ! $thread_id ) {
+            tanviz_log_error( 'OpenAI thread create: missing id' );
+            return array( 'ok' => false, 'error' => 'no_thread_id', 'raw' => wp_remote_retrieve_body( $resp ) );
+        }
+    }
 
-    $body = array(
-        'model' => $model,
-        'temperature' => 0.2,
-        'max_output_tokens' => 3000,
-        'input' => array(
-            array( 'role' => 'system', 'content' => 'Eres un experto en p5.js. Entrega ÚNICAMENTE el archivo final p5.js entre marcadores.' ),
-            array( 'role' => 'user', 'content' => $prompt ),
-        ),
+    if ( $dataset_url && ! $args['thread_id'] ) {
+        $content = "Eres un experto en p5.js. Entrega ÚNICAMENTE el archivo final p5.js listo para ejecutar.\n\n" .
+            "ENTRADAS\n" .
+            "- PROMPT DEL USUARIO: {$prompt_user}\n" .
+            "- DATASET_URL: {$dataset_url}\n" .
+            "- Placeholders disponibles: {{col.year}}, {{col.value}} (no hardcodear cabeceras/URLs)\n\n" .
+            "CONTRATO OBLIGATORIO\n" .
+            "1) Estructura: define preload(), setup(), draw(), y windowResized() si procede. Declara helpers antes de usarlos.\n" .
+            "2) Carga de datos: usa SOLO funciones de p5.js (loadTable/loadJSON) con {$dataset_url}.\n" .
+            "3) Placeholders: usa {{col.*}} (p. ej., {{col.year}}, {{col.value}}). Prohibido datos de ejemplo/muestras.\n" .
+            "4) Rangos dinámicos: calcula yearMin/yearMax y min/max de valores.\n" .
+            "5) Prohibido: eval(), import(), fetch(), XHR, CSS externo.\n" .
+            "6) Respuesta: devuelve EXCLUSIVAMENTE el código entre:\n" .
+            "-----BEGIN_P5JS-----\n" .
+            "...AQUÍ VA EL CÓDIGO...\n" .
+            "-----END_P5JS-----";
+    } else {
+        $content = $prompt_user;
+    }
+
+    $msg_body = array(
+        'role'    => 'user',
+        'content' => $content,
     );
-
-    $args_http = array(
-        'headers' => array(
-            'Authorization' => 'Bearer ' . trim( get_option( 'tanviz_openai_api_key', '' ) ),
-            'Content-Type'  => 'application/json',
-        ),
+    $resp = wp_remote_post( "https://api.openai.com/v1/threads/{$thread_id}/messages", array(
+        'headers' => $headers,
         'timeout' => 60,
-        'body'    => wp_json_encode( $body ),
-    );
-
-    $resp = wp_remote_post( 'https://api.openai.com/v1/responses', $args_http );
+        'body'    => wp_json_encode( $msg_body ),
+    ) );
     if ( is_wp_error( $resp ) ) {
-        tanviz_log_error( 'OpenAI request failed: ' . $resp->get_error_message() );
+        tanviz_log_error( 'OpenAI message failed: ' . $resp->get_error_message() );
         return array( 'ok' => false, 'error' => $resp->get_error_message(), 'raw' => '' );
     }
 
-    $raw  = wp_remote_retrieve_body( $resp );
-    $code = wp_remote_retrieve_response_code( $resp );
-    if ( $code < 200 || $code >= 300 ) {
-        tanviz_log_error( 'OpenAI HTTP error ' . $code . ': ' . $raw );
-        return array( 'ok' => false, 'error' => 'http_' . $code, 'raw' => $raw );
+    $run_body = array( 'assistant_id' => $assistant_id, 'model' => $model );
+    $resp = wp_remote_post( "https://api.openai.com/v1/threads/{$thread_id}/runs", array(
+        'headers' => $headers,
+        'timeout' => 60,
+        'body'    => wp_json_encode( $run_body ),
+    ) );
+    if ( is_wp_error( $resp ) ) {
+        tanviz_log_error( 'OpenAI run failed: ' . $resp->get_error_message() );
+        return array( 'ok' => false, 'error' => $resp->get_error_message(), 'raw' => '' );
+    }
+    $json   = json_decode( wp_remote_retrieve_body( $resp ), true );
+    $run_id = $json['id'] ?? '';
+    if ( ! $run_id ) {
+        tanviz_log_error( 'OpenAI run: missing id' );
+        return array( 'ok' => false, 'error' => 'no_run_id', 'raw' => wp_remote_retrieve_body( $resp ) );
     }
 
-    $json = json_decode( $raw, true );
-    $text = '';
-    if ( is_array( $json ) ) {
-        if ( ! empty( $json['output'] ) && is_array( $json['output'] ) ) {
-            foreach ( $json['output'] as $item ) {
-                foreach ( ( $item['content'] ?? array() ) as $c ) {
-                    if ( isset( $c['text'] ) && is_string( $c['text'] ) ) {
-                        $text .= $c['text'];
-                    }
+    $status = '';
+    for ( $i = 0; $i < 15; $i++ ) {
+        $resp = wp_remote_get( "https://api.openai.com/v1/threads/{$thread_id}/runs/{$run_id}", array(
+            'headers' => $headers,
+            'timeout' => 60,
+        ) );
+        if ( is_wp_error( $resp ) ) {
+            tanviz_log_error( 'OpenAI run status failed: ' . $resp->get_error_message() );
+            return array( 'ok' => false, 'error' => $resp->get_error_message(), 'raw' => '' );
+        }
+        $json   = json_decode( wp_remote_retrieve_body( $resp ), true );
+        $status = $json['status'] ?? '';
+        if ( in_array( $status, array( 'completed', 'failed', 'cancelled', 'expired' ), true ) ) {
+            break;
+        }
+        sleep( 2 );
+    }
+    if ( 'completed' !== $status ) {
+        tanviz_log_error( 'OpenAI run status: ' . $status );
+        return array( 'ok' => false, 'error' => 'run_' . $status, 'raw' => '', 'thread_id' => $thread_id );
+    }
+
+    $resp = wp_remote_get( "https://api.openai.com/v1/threads/{$thread_id}/messages", array(
+        'headers' => $headers,
+        'timeout' => 60,
+    ) );
+    if ( is_wp_error( $resp ) ) {
+        tanviz_log_error( 'OpenAI messages failed: ' . $resp->get_error_message() );
+        return array( 'ok' => false, 'error' => $resp->get_error_message(), 'raw' => '', 'thread_id' => $thread_id );
+    }
+    $json = json_decode( wp_remote_retrieve_body( $resp ), true );
+    $msgs = array();
+    if ( isset( $json['data'] ) && is_array( $json['data'] ) ) {
+        $ordered = array_reverse( $json['data'] );
+        foreach ( $ordered as $m ) {
+            $role = $m['role'] ?? '';
+            $text = '';
+            foreach ( $m['content'] ?? array() as $c ) {
+                if ( isset( $c['text']['value'] ) ) {
+                    $text .= $c['text']['value'];
                 }
             }
+            $msgs[] = array( 'role' => $role, 'text' => $text );
         }
-        if ( $text === '' && isset( $json['output_text'] ) ) {
-            $text = (string) $json['output_text'];
-        }
-    } else {
-        $text = $raw;
     }
 
-    $block = tanviz_extract_p5_block( $text );
-    if ( ! $block['ok'] ) {
+    $codigo = '';
+    for ( $i = count( $msgs ) - 1; $i >= 0; $i-- ) {
+        if ( $msgs[ $i ]['role'] === 'assistant' ) {
+            $block = tanviz_extract_p5_block( $msgs[ $i ]['text'] );
+            if ( $block['ok'] ) {
+                $codigo = $block['codigo'];
+                break;
+            }
+        }
+    }
+    if ( ! $codigo ) {
         tanviz_log_error( 'Missing p5.js code block in OpenAI response.' );
-        return array( 'ok' => false, 'error' => 'no_block', 'raw' => $text );
+        return array( 'ok' => false, 'error' => 'no_block', 'raw' => wp_remote_retrieve_body( $resp ), 'thread_id' => $thread_id, 'messages' => $msgs );
     }
 
-    return array( 'ok' => true, 'codigo' => $block['codigo'] );
+    return array( 'ok' => true, 'codigo' => $codigo, 'thread_id' => $thread_id, 'messages' => $msgs );
 }

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -4,6 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
 function tanviz_register_settings() {
     register_setting( 'tanviz_settings', 'tanviz_openai_api_key', [ 'type' => 'string', 'sanitize_callback' => 'sanitize_text_field' ] );
     register_setting( 'tanviz_settings', 'tanviz_model', [ 'type' => 'string', 'sanitize_callback' => 'sanitize_text_field', 'default' => 'gpt-4o-2024-08-06' ] );
+    register_setting( 'tanviz_settings', 'tanviz_assistant_id', [ 'type' => 'string', 'sanitize_callback' => 'sanitize_text_field' ] );
     register_setting( 'tanviz_settings', 'tanviz_datasets_base', [ 'type'=>'string', 'sanitize_callback'=>'esc_url_raw' ] );
     register_setting( 'tanviz_settings', 'tanviz_logo_url', [ 'type'=>'string', 'sanitize_callback'=>'esc_url_raw', 'default'=> plugins_url('assets/logo.png', dirname(__FILE__,1) . '/../TanViz.php') ] );
 
@@ -17,6 +18,11 @@ function tanviz_register_settings() {
     add_settings_field( 'tanviz_model', __( 'OpenAI Model', 'TanViz' ), function(){
         $v = esc_attr( get_option( 'tanviz_model', 'gpt-4o-2024-08-06' ) );
         echo '<input type="text" name="tanviz_model" value="' . $v . '" class="regular-text" />';
+    }, 'tanviz', 'tanviz_main' );
+
+    add_settings_field( 'tanviz_assistant_id', __( 'OpenAI Assistant ID', 'TanViz' ), function(){
+        $v = esc_attr( get_option( 'tanviz_assistant_id', '' ) );
+        echo '<input type="text" name="tanviz_assistant_id" value="' . $v . '" class="regular-text code" />';
     }, 'tanviz', 'tanviz_main' );
 
 


### PR DESCRIPTION
## Summary
- switch OpenAI calls to Assistants API and add assistant ID setting
- introduce chat thread UI in sandbox with AI code copy box
- add REST endpoints and JS logic for threaded conversations

## Testing
- `php -l includes/settings.php includes/admin-ui.php includes/rest.php includes/openai.php`
- `node --check assets/admin.js`


------
https://chatgpt.com/codex/tasks/task_e_689faddf0804833298624b111d3a851f