### PR TITLE
chore: differentiate assistants api version

### DIFF
--- a/TanViz.php
+++ b/TanViz.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: TanViz
- * Description: Admin-only generator of generative p5.js visualizations using OpenAI Responses API (JSON Schema). Includes Settings, Sandbox, and Library.
+ * Description: Admin-only generator of generative p5.js visualizations using the OpenAI Assistants API with JSON Schema. Includes Settings, Sandbox, and Library.
  * Version: 0.1.0
  * Author: Antonio Moneo + ChatGPT
  * Text Domain: TanViz

--- a/assets/js/client-error-logger.js
+++ b/assets/js/client-error-logger.js
@@ -23,7 +23,7 @@
       };
       if (meta.datasetUrl) payload.dataset_url = meta.datasetUrl;
       if (meta.code) payload.code_hash = (await sha1Hex(meta.code)).slice(0,12);
-      fetch('/wp-json/tanviz/v1/logs', {
+      fetch('/wp-json/tanvizassistant/v1/logs', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),

--- a/includes/admin-ui.php
+++ b/includes/admin-ui.php
@@ -14,13 +14,13 @@ function tanviz_admin_assets( $hook ){
     wp_enqueue_script('tanviz-admin', TANVIZ_URL.'assets/admin.js', ['jquery'], TANVIZ_VERSION, true );
     wp_localize_script('tanviz-admin','TanVizCfg',[
         'rest' => [
-            'generate' => esc_url_raw( rest_url('TanViz/v1/generate') ),
-            'datasets' => esc_url_raw( rest_url('TanViz/v1/datasets') ),
-            'sample'   => esc_url_raw( rest_url('TanViz/v1/sample') ),
-            'save'     => esc_url_raw( rest_url('TanViz/v1/save') ),
-            'fix'      => esc_url_raw( rest_url('TanViz/v1/fix') ),
-            'ask'      => esc_url_raw( rest_url('TanViz/v1/ask') ),
-            'chat'     => esc_url_raw( rest_url('TanViz/v1/chat') ),
+            'generate' => esc_url_raw( rest_url('TanVizAssistant/v1/generate') ),
+            'datasets' => esc_url_raw( rest_url('TanVizAssistant/v1/datasets') ),
+            'sample'   => esc_url_raw( rest_url('TanVizAssistant/v1/sample') ),
+            'save'     => esc_url_raw( rest_url('TanVizAssistant/v1/save') ),
+            'fix'      => esc_url_raw( rest_url('TanVizAssistant/v1/fix') ),
+            'ask'      => esc_url_raw( rest_url('TanVizAssistant/v1/ask') ),
+            'chat'     => esc_url_raw( rest_url('TanVizAssistant/v1/chat') ),
         ],
         'nonce' => wp_create_nonce('wp_rest'),
         'logo'  => esc_url( get_option('tanviz_logo_url', TANVIZ_URL.'assets/logo.png') ),

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -8,7 +8,7 @@ require_once TANVIZ_PATH . 'includes/datasets.php';
 require_once TANVIZ_PATH . 'includes/utils-logging.php';
 
 add_action('rest_api_init', function(){
-    register_rest_route('TanViz/v1','/generate',[
+    register_rest_route('TanVizAssistant/v1','/generate',[
         'methods'  => 'POST',
         'permission_callback' => function(){ return current_user_can('manage_options'); },
         'callback' => 'tanviz_rest_generate',
@@ -19,7 +19,7 @@ add_action('rest_api_init', function(){
         ],
     ]);
 
-    register_rest_route('TanViz/v1','/chat',[
+    register_rest_route('TanVizAssistant/v1','/chat',[
         'methods'  => 'POST',
         'permission_callback' => function(){ return current_user_can('manage_options'); },
         'callback' => 'tanviz_rest_chat',
@@ -29,7 +29,7 @@ add_action('rest_api_init', function(){
         ],
     ]);
 
-    register_rest_route('TanViz/v1','/datasets',[
+    register_rest_route('TanVizAssistant/v1','/datasets',[
         'methods'  => 'GET',
         'permission_callback' => function(){ return current_user_can('manage_options'); },
         'callback' => function(){
@@ -38,7 +38,7 @@ add_action('rest_api_init', function(){
         },
     ]);
 
-    register_rest_route('TanViz/v1','/sample',[
+    register_rest_route('TanVizAssistant/v1','/sample',[
         'methods'  => 'GET',
         'permission_callback' => function(){ return current_user_can('manage_options'); },
         'callback' => function( WP_REST_Request $req ){
@@ -49,7 +49,7 @@ add_action('rest_api_init', function(){
         'args' => [ 'url' => ['required'=>true] ],
     ]);
 
-    register_rest_route('TanViz/v1','/save',[
+    register_rest_route('TanVizAssistant/v1','/save',[
         'methods'  => 'POST',
         'permission_callback' => function(){ return current_user_can('manage_options'); },
         'callback' => 'tanviz_rest_save',
@@ -61,7 +61,7 @@ add_action('rest_api_init', function(){
         ],
     ]);
 
-    register_rest_route('TanViz/v1','/fix',[
+    register_rest_route('TanVizAssistant/v1','/fix',[
         'methods'  => 'POST',
         'permission_callback' => function(){ return current_user_can('manage_options'); },
         'callback' => 'tanviz_rest_fix',
@@ -71,7 +71,7 @@ add_action('rest_api_init', function(){
         ],
     ]);
 
-    register_rest_route('TanViz/v1','/ask',[
+    register_rest_route('TanVizAssistant/v1','/ask',[
         'methods'  => 'POST',
         'permission_callback' => function(){ return current_user_can('manage_options'); },
         'callback' => 'tanviz_rest_ask',
@@ -80,7 +80,7 @@ add_action('rest_api_init', function(){
         ],
     ]);
 
-    register_rest_route('tanviz/v1','/logs',[
+    register_rest_route('tanvizassistant/v1','/logs',[
         'methods'  => 'POST',
         'permission_callback' => '__return_true',
         'callback' => function( WP_REST_Request $req ){


### PR DESCRIPTION
## Summary
- clarify plugin description to note it uses the OpenAI Assistants API
- move REST endpoints to new `TanVizAssistant/v1` namespace and adjust client error logger hook

## Testing
- `php -l TanViz.php`
- `php -l includes/rest.php`
- `php -l includes/admin-ui.php`
- `node --check assets/js/client-error-logger.js`


------
https://chatgpt.com/codex/tasks/task_e_689fb09268408332b3759b8089d1a3e5