### PR TITLE
Fix button conversation by standardizing code field

### DIFF
--- a/includes/openai.php
+++ b/includes/openai.php
@@ -142,20 +142,20 @@ function tanviz_openai_assistant_chat( array $args ): array {
         }
     }
 
-    $codigo = '';
+    $code = '';
     for ( $i = count( $msgs ) - 1; $i >= 0; $i-- ) {
         if ( $msgs[ $i ]['role'] === 'assistant' ) {
             $block = tanviz_extract_p5_block( $msgs[ $i ]['text'] );
             if ( $block['ok'] ) {
-                $codigo = $block['codigo'];
+                $code = $block['code'];
                 break;
             }
         }
     }
-    if ( ! $codigo ) {
+    if ( ! $code ) {
         tanviz_log_error( 'Missing p5.js code block in OpenAI response.' );
         return array( 'ok' => false, 'error' => 'no_block', 'raw' => wp_remote_retrieve_body( $resp ), 'thread_id' => $thread_id, 'messages' => $msgs );
     }
 
-    return array( 'ok' => true, 'codigo' => $codigo, 'thread_id' => $thread_id, 'messages' => $msgs );
+    return array( 'ok' => true, 'code' => $code, 'thread_id' => $thread_id, 'messages' => $msgs );
 }

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -202,8 +202,8 @@ function tanviz_rest_generate( WP_REST_Request $req ) {
         return new WP_Error( 'tanviz_openai_error', $resp['error'], array( 'raw' => $resp['raw'] ) );
     }
 
-    $codigo = $resp['codigo'];
-    $val    = tanviz_validate_p5_code( $codigo );
+    $code = $resp['code'];
+    $val  = tanviz_validate_p5_code( $code );
     if ( ! $val['ok'] ) {
         $err_txt = implode( ', ', $val['errors'] );
         tanviz_log_error([
@@ -219,7 +219,7 @@ function tanviz_rest_generate( WP_REST_Request $req ) {
             "Manejo de Errores: captura fallos al cargar CSV (URL incorrecta/archivo no disponible).",
             "Optimización: usa noLoop() para visualización estática.",
         ]);
-        $prompt_fix = "Corrige el código p5.js basándote en los errores detectados. Debes reemplazar ÚNICAMENTE lo imprescindible y devolver el archivo COMPLETO listo para ejecutar.\n\nOBJETIVO\n- Entregar SOLO el código final p5.js entre marcadores.\n\nCONTEXTO\nERROR EN VALIDACIÓN:\n{$err_txt}\n\nCÓDIGO ACTUAL:\n{$codigo}\n\nREGLAS DE CORRECCIÓN (OBLIGATORIAS)\n1) Sustitución mínima: conserva intención original.\n2) Estructura p5.js: preload(), setup(), draw() y helpers usados.\n3) Mantén dataset/URLs/placeholders existentes.\n4) Prohibido eval/import/fetch/XHR y datos de ejemplo.\n\nResponde entre:\n-----BEGIN_P5JS-----\n...CÓDIGO CORREGIDO...\n-----END_P5JS-----";
+        $prompt_fix = "Corrige el código p5.js basándote en los errores detectados. Debes reemplazar ÚNICAMENTE lo imprescindible y devolver el archivo COMPLETO listo para ejecutar.\n\nOBJETIVO\n- Entregar SOLO el código final p5.js entre marcadores.\n\nCONTEXTO\nERROR EN VALIDACIÓN:\n{$err_txt}\n\nCÓDIGO ACTUAL:\n{$code}\n\nREGLAS DE CORRECCIÓN (OBLIGATORIAS)\n1) Sustitución mínima: conserva intención original.\n2) Estructura p5.js: preload(), setup(), draw() y helpers usados.\n3) Mantén dataset/URLs/placeholders existentes.\n4) Prohibido eval/import/fetch/XHR y datos de ejemplo.\n\nResponde entre:\n-----BEGIN_P5JS-----\n...CÓDIGO CORREGIDO...\n-----END_P5JS-----";
 
         $retry = tanviz_openai_assistant_chat( [
             'dataset_url'    => $dataset_url,
@@ -249,8 +249,8 @@ function tanviz_rest_generate( WP_REST_Request $req ) {
             }
             return new WP_Error( 'tanviz_openai_error', $retry['error'], array( 'raw' => $retry['raw'] ) );
         }
-        $codigo   = $retry['codigo'];
-        $val      = tanviz_validate_p5_code( $codigo );
+        $code   = $retry['code'];
+        $val    = tanviz_validate_p5_code( $code );
         $thread_id = $retry['thread_id'] ?? $thread_id;
         $messages  = $retry['messages'] ?? $messages;
         if ( ! $val['ok'] ) {
@@ -275,10 +275,10 @@ function tanviz_rest_generate( WP_REST_Request $req ) {
         'model'        => $model,
         'dataset_url'  => $dataset_url,
         'prompt_hash'  => $prompt_hash,
-        'response_size'=> strlen( $codigo ),
+        'response_size'=> strlen( $code ),
     ]);
 
-    return new WP_REST_Response( array( 'success' => true, 'code' => $codigo, 'thread_id' => $thread_id, 'messages' => $messages ), 200 );
+    return new WP_REST_Response( array( 'success' => true, 'code' => $code, 'thread_id' => $thread_id, 'messages' => $messages ), 200 );
 }
 
 function tanviz_rest_chat( WP_REST_Request $req ) {
@@ -308,7 +308,7 @@ function tanviz_rest_chat( WP_REST_Request $req ) {
         return new WP_Error( 'tanviz_openai_error', $resp['error'], array( 'raw' => $resp['raw'] ) );
     }
 
-    return new WP_REST_Response( array( 'success'=>true, 'code'=>$resp['codigo'] ?? '', 'thread_id'=>$resp['thread_id'], 'messages'=>$resp['messages'] ), 200 );
+    return new WP_REST_Response( array( 'success'=>true, 'code'=>$resp['code'] ?? '', 'thread_id'=>$resp['thread_id'], 'messages'=>$resp['messages'] ), 200 );
 }
 
 function tanviz_rest_ask( WP_REST_Request $req ) {
@@ -517,7 +517,7 @@ PROMPT;
 
     $code_fixed = tanviz_normalize_p5_code( $out );
 
-    return new WP_REST_Response( [ 'ok' => true, 'codigo' => $code_fixed ], 200 );
+    return new WP_REST_Response( [ 'ok' => true, 'code' => $code_fixed ], 200 );
 }
 
 function tanviz_rest_save( WP_REST_Request $req ) {

--- a/includes/schema.php
+++ b/includes/schema.php
@@ -5,7 +5,7 @@ function tanviz_p5_json_schema() {
     return [
         'type'       => 'object',
         'properties' => [
-            'codigo' => [
+            'code' => [
                 'type'        => 'string',
                 'description' => 'Código p5.js que genera la visualización.',
             ],
@@ -14,7 +14,7 @@ function tanviz_p5_json_schema() {
                 'description' => 'Descripción breve de la visualización.',
             ],
         ],
-        'required' => [ 'codigo', 'descripcion' ],
+        'required' => [ 'code', 'descripcion' ],
         'additionalProperties' => false,
     ];
 }

--- a/includes/validators.php
+++ b/includes/validators.php
@@ -11,7 +11,7 @@ function tanviz_extract_p5_block( string $text ): array {
     if ( ! preg_match( '/-----BEGIN_P5JS-----\s*([\s\S]*?)\s*-----END_P5JS-----/u', $text, $m ) ) {
         return array( 'ok' => false, 'error' => 'no_block' );
     }
-    return array( 'ok' => true, 'codigo' => trim( $m[1] ) );
+    return array( 'ok' => true, 'code' => trim( $m[1] ) );
 }
 
 /**


### PR DESCRIPTION
## Summary
- Standardize OpenAI helper to return `code` instead of `codigo`
- Update REST endpoints and schema to use unified `code` key
- Adjust validator to expose extracted p5.js code via `code`

## Testing
- `php -l includes/openai.php`
- `php -l includes/rest.php`
- `php -l includes/validators.php`
- `php -l includes/schema.php`


------
https://chatgpt.com/codex/tasks/task_e_689fb1921aa083328803d8b6c791d7ec