### PR TITLE
feat: show API request response under generator

### DIFF
--- a/includes/admin-ui.php
+++ b/includes/admin-ui.php
@@ -62,6 +62,7 @@ function tanviz_render_sandbox(){
           <h2><?php echo esc_html__('Dataset sample','TanViz'); ?></h2>
           <pre id="tanviz-sample"></pre>
           <p><button class="button button-primary" id="tanviz-generate"><?php echo esc_html__('Generate visualization','TanViz'); ?></button></p>
+          <details id="tanviz-rr-wrap"><summary><?php echo esc_html__( 'Request/Response', 'TanViz' ); ?></summary><pre id="tanviz-rr"></pre><p><button class="button" id="tanviz-copy-rr"><?php echo esc_html__('Copy','TanViz'); ?></button></p></details>
           <h2><?php echo esc_html__('Conversation','TanViz'); ?></h2>
           <div id="tanviz-thread" class="tanviz-thread"></div>
           <textarea id="tanviz-chat-input" rows="3" class="large-text"></textarea>
@@ -77,7 +78,6 @@ function tanviz_render_sandbox(){
              <button class="button" id="tanviz-ask"><?php echo esc_html__('Ask AI','TanViz'); ?></button>
              <button class="button" id="tanviz-fix"><?php echo esc_html__('Fix','TanViz'); ?></button>
              <button class="button" id="tanviz-run"><?php echo esc_html__('Run','TanViz'); ?></button></p>
-          <details id="tanviz-rr-wrap"><summary><?php echo esc_html__( 'Request/Response', 'TanViz' ); ?></summary><pre id="tanviz-rr"></pre><p><button class="button" id="tanviz-copy-rr"><?php echo esc_html__('Copy','TanViz'); ?></button></p></details>
         </section>
         <section>
           <h2><?php echo esc_html__('Preview','TanViz'); ?></h2>


### PR DESCRIPTION
## Summary
- show request and response directly beneath Generate visualization button

## Testing
- `npm test`
- `composer test`
- `php -l includes/admin-ui.php`


------
https://chatgpt.com/codex/tasks/task_e_689fb36f15e083328cf91f929ebbe81e