### PR TITLE
Fix missing thread id by sending Assistants v2 header

### DIFF
--- a/includes/openai.php
+++ b/includes/openai.php
@@ -25,6 +25,7 @@ function tanviz_openai_assistant_chat( array $args ): array {
     $headers = array(
         'Authorization' => 'Bearer ' . $api_key,
         'Content-Type'  => 'application/json',
+        'OpenAI-Beta'   => 'assistants=v2',
     );
 
     if ( ! $thread_id ) {


### PR DESCRIPTION
## Summary
- Send `OpenAI-Beta: assistants=v2` header with all OpenAI requests to ensure thread IDs are returned

## Testing
- `php -l includes/openai.php`


------
https://chatgpt.com/codex/tasks/task_e_689fb542076c8332b9d014d8c1bc678d