### PR TITLE
feat: style chat conversation with copyable code

### DIFF
--- a/assets/admin.css
+++ b/assets/admin.css
@@ -5,3 +5,11 @@
 .tanviz-wrap iframe{width:100%;aspect-ratio:16/9;border:1px solid #ccd0d4}
 #tanviz-sample,#tanviz-rr,#tanviz-console{max-height:40vh;overflow:auto;background:#f8f8f8;padding:.5rem;border:1px solid #ccd0d4;white-space:pre-wrap;overflow-wrap:anywhere}
 .tanviz-meta-box{background:#fff;border:1px solid #ccd0d4;padding:1rem;margin-top:1rem}
+
+.tanviz-thread{display:flex;flex-direction:column;gap:.5rem;max-height:40vh;overflow:auto}
+.tanviz-msg{padding:.5rem .75rem;border-radius:8px;max-width:80%}
+.tanviz-user{background:#e0f7fa;align-self:flex-start}
+.tanviz-assistant{background:#f1f8e9;align-self:flex-end}
+.tanviz-code-block{position:relative}
+.tanviz-code-block .tanviz-copy{position:absolute;top:4px;right:4px}
+.tanviz-code{background:#f5f5f5;padding:.5rem;margin-top:0;overflow:auto}

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -91,14 +91,37 @@
 
   function renderThread(msgs){
     const $t = $('#tanviz-thread');
-    $t.text('');
-    (msgs||[]).forEach(m=>{
+    $t.empty();
+    (msgs||[]).forEach(m => {
       const role = m.role;
-      const text = m.text;
-      const div = $('<div class="tanviz-msg tanviz-'+role+'"></div>').text(role+': '+text);
-      $t.append(div);
+      const text = m.text || '';
+      const $msg = $('<div class="tanviz-msg tanviz-' + role + '"></div>');
+      const codeMatch = text.match(/```([\s\S]*?)```/);
+      if (codeMatch) {
+        const before = text.slice(0, codeMatch.index).trim();
+        const after = text.slice(codeMatch.index + codeMatch[0].length).trim();
+        if (before) { $msg.append($('<p></p>').text(before)); }
+        let code = codeMatch[1];
+        const firstLineBreak = code.indexOf('\n');
+        if (firstLineBreak !== -1) {
+          code = code.slice(firstLineBreak + 1); // drop language hint
+        }
+        const $pre = $('<pre class="tanviz-code"></pre>').text(code);
+        const $btn = $('<button class="button tanviz-copy">Copy</button>');
+        const $codeWrap = $('<div class="tanviz-code-block"></div>').append($btn).append($pre);
+        $msg.append($codeWrap);
+        if (after) { $msg.append($('<p></p>').text(after)); }
+      } else {
+        $msg.text(text);
+      }
+      $t.append($msg);
     });
   }
+
+  $(document).on('click', '.tanviz-copy', function(){
+    const code = $(this).siblings('pre').text();
+    navigator.clipboard.writeText(code);
+  });
 
   $(document).on('click','#tanviz-chat-send',function(e){
     e.preventDefault();


### PR DESCRIPTION
## Summary
- add chat bubble styles and copy button for AI code snippets in conversation thread
- render assistant messages with code blocks and clipboard support

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fba2826bc83328788b4fcd528f40c