### PR TITLE
Allow conversation responses without p5.js code

### DIFF
--- a/assets/admin.js
+++ b/assets/admin.js
@@ -74,9 +74,7 @@
       const r = unwrapResponse(resp);
       threadId = r.thread_id || '';
       renderThread(r.messages);
-      if (r && (r.success || r.ok) && r.code){
-        $('#tanviz-ai-code').val(r.code);
-      } else {
+      if (!(r && (r.success || r.ok))){
         $('#tanviz-console').text('Error inesperado. Reintenta.');
       }
     }).fail(function(xhr){
@@ -140,7 +138,6 @@
       $('#tanviz-rr').text(JSON.stringify({request:{thread_id:threadId,message},response:resp},null,2));
       const r = unwrapResponse(resp);
       renderThread(r.messages);
-      if(r.code){ $('#tanviz-ai-code').val(r.code); }
     }).fail(function(xhr){
       $('#tanviz-rr').text(xhr.responseText || 'Error');
     });

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -297,6 +297,7 @@ function tanviz_rest_chat( WP_REST_Request $req ) {
             'thread_id'      => $thread_id,
             'prompt_usuario' => $message,
             'model'          => $model,
+            'expect_code'    => false,
         ] );
     } catch ( Throwable $e ) {
         tanviz_log_error([ 'action'=>'chat', 'message'=>$e->getMessage() ]);
@@ -308,7 +309,7 @@ function tanviz_rest_chat( WP_REST_Request $req ) {
         return new WP_Error( 'tanviz_openai_error', $resp['error'], array( 'raw' => $resp['raw'] ) );
     }
 
-    return new WP_REST_Response( array( 'success'=>true, 'code'=>$resp['code'] ?? '', 'thread_id'=>$resp['thread_id'], 'messages'=>$resp['messages'] ), 200 );
+    return new WP_REST_Response( array( 'success'=>true, 'thread_id'=>$resp['thread_id'], 'messages'=>$resp['messages'] ), 200 );
 }
 
 function tanviz_rest_ask( WP_REST_Request $req ) {


### PR DESCRIPTION
## Summary
- Allow OpenAI conversation responses that do not contain p5.js code
- Remove automatic injection of assistant code into the editor UI

## Testing
- `php -l includes/openai.php includes/rest.php`
- `node --check assets/admin.js`


------
https://chatgpt.com/codex/tasks/task_e_68a0440cfb948332be95cd58b5c8c27e