### PR TITLE
Improve code box responsiveness and auto code extraction

### DIFF
--- a/assets/admin.css
+++ b/assets/admin.css
@@ -4,13 +4,13 @@
 .tanviz-grid section{background:#fff;border:1px solid #ccd0d4;padding:1rem}
 .tanviz-wrap iframe{width:100%;aspect-ratio:16/9;border:1px solid #ccd0d4}
 #tanviz-sample,#tanviz-console{max-height:40vh;overflow:auto;background:#f8f8f8;padding:.5rem;border:1px solid #ccd0d4;white-space:pre-wrap;overflow-wrap:anywhere}
-#tanviz-rr{max-height:40vh;border:1px solid #ccd0d4;overflow:auto;width:100%;white-space:pre-wrap;overflow-wrap:anywhere}
+#tanviz-rr{max-height:40vh;overflow:auto;width:100%;white-space:pre-wrap;overflow-wrap:anywhere}
 .tanviz-meta-box{background:#fff;border:1px solid #ccd0d4;padding:1rem;margin-top:1rem}
 
 .tanviz-thread{display:flex;flex-direction:column;gap:.5rem;height:40vh;overflow:auto}
 .tanviz-msg{padding:.5rem .75rem;border-radius:8px;max-width:80%;white-space:pre-wrap;overflow-wrap:anywhere}
 .tanviz-user{background:#e0f7fa;align-self:flex-start}
 .tanviz-assistant{background:#f1f8e9;align-self:flex-end}
-.tanviz-code-block{position:relative}
+.tanviz-code-block{position:relative;background:#f8f8f8;border:1px solid #ccd0d4}
 .tanviz-code-block .tanviz-copy{position:absolute;top:4px;right:4px}
-.tanviz-code{background:#f5f5f5;padding:.5rem;margin-top:0;overflow:auto;white-space:pre;max-width:100%}
+.tanviz-code{padding:.5rem;margin:0;overflow:auto;white-space:pre-wrap;overflow-wrap:anywhere;font-family:monospace;max-width:100%}

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -90,6 +90,7 @@
   function renderThread(msgs){
     const $t = $('#tanviz-thread');
     $t.empty();
+    let lastCode = '';
     (msgs||[]).forEach(m => {
       const role = m.role;
       const text = m.text || '';
@@ -104,6 +105,8 @@
         if (firstLineBreak !== -1) {
           code = code.slice(firstLineBreak + 1); // drop language hint
         }
+        code = code.trim();
+        if (role === 'assistant') { lastCode = code; }
         const $pre = $('<pre class="tanviz-code"></pre>').text(code);
         const $btn = $('<button class="button tanviz-copy">Copy</button>');
         const $codeWrap = $('<div class="tanviz-code-block"></div>').append($btn).append($pre);
@@ -114,6 +117,10 @@
       }
       $t.append($msg);
     });
+    if (lastCode) {
+      $('#tanviz-ai-code').val(lastCode);
+      setCode(lastCode);
+    }
   }
 
   $(document).on('click', '.tanviz-copy', function(){


### PR DESCRIPTION
## Summary
- style conversation and request/response code blocks with responsive wrapping and copy-ready container
- automatically extract assistant code into AI code textarea and editor

## Testing
- `node --check assets/admin.js`
- `php -l TanViz.php`


------
https://chatgpt.com/codex/tasks/task_e_68a09684ddd08332a8ee44591898daa7