### PR TITLE
Remove placeholders and fix newline handling

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -1,6 +1,6 @@
 # Lecciones aprendidas
 
-- **Placeholders correctos**: Reemplaza `{{col.year}}` y `{{col.value}}` con los nombres reales de las columnas del dataset.
+- **Cabeceras reales**: Usa directamente los nombres de las columnas del dataset, sin placeholders.
 - **Dependencia de `preload()`**: Esta función bloquea la ejecución hasta que los datos se cargan; toma en cuenta su impacto en el tiempo de carga.
 - **Manejo de errores**: Maneja errores en la carga de datos mostrando mensajes en la consola y, si es posible, también en la visualización.
 - **Verificación de `table`**: Cuando se usa `preload()`, la tabla estará disponible en `draw()` y no necesita comprobaciones redundantes.

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -52,7 +52,7 @@
       const $c = $('#tanviz-console');
       const txt = $c.text();
       const prefix = e.data.type === 'tanviz-error' ? 'ERROR: ' : '';
-      $c.text(txt + (txt ? '\n' : '') + prefix + e.data.message);
+      $c.text(txt + (txt ? String.fromCharCode(10) : '') + prefix + e.data.message);
     }
   });
 
@@ -80,9 +80,9 @@
     }).fail(function(xhr){
       let msg = xhr.responseJSON && xhr.responseJSON.message ? xhr.responseJSON.message : (xhr.responseText || 'Error');
       if (xhr.responseJSON && xhr.responseJSON.data && xhr.responseJSON.data.errors){
-        msg += '\n' + xhr.responseJSON.data.errors.join(', ');
+        msg += String.fromCharCode(10) + xhr.responseJSON.data.errors.join(', ');
       }
-      $('#tanviz-console').text(msg + '\nReintenta.');
+      $('#tanviz-console').text(msg + String.fromCharCode(10) + 'Reintenta.');
       $('#tanviz-rr').text(msg);
     });
   });
@@ -102,8 +102,9 @@
         const after = text.slice(codeMatch.index + codeMatch[0].length).trim();
         if (before) { $msg.append($('<p></p>').text(before)); }
         let code = codeMatch[1];
+        code = code.replace(/\\n/g, String.fromCharCode(10));
         if (!markerMatch) {
-          const firstLineBreak = code.indexOf('\n');
+          const firstLineBreak = code.indexOf(String.fromCharCode(10));
           if (firstLineBreak !== -1) {
             code = code.slice(firstLineBreak + 1); // drop language hint
           }

--- a/includes/openai.php
+++ b/includes/openai.php
@@ -52,14 +52,12 @@ function tanviz_openai_assistant_chat( array $args ): array {
             "ENTRADAS\n" .
             "- PROMPT DEL USUARIO: {$prompt_user}\n" .
             "- DATASET_URL: {$dataset_url}\n" .
-            "- Placeholders disponibles: {{col.year}}, {{col.value}} (no hardcodear cabeceras/URLs)\n\n" .
-            "CONTRATO OBLIGATORIO\n" .
+            "\nCONTRATO OBLIGATORIO\n" .
             "1) Estructura: define preload(), setup(), draw(), y windowResized() si procede. Declara helpers antes de usarlos.\n" .
             "2) Carga de datos: usa SOLO funciones de p5.js (loadTable/loadJSON) con {$dataset_url}.\n" .
-            "3) Placeholders: usa {{col.*}} (p. ej., {{col.year}}, {{col.value}}). Prohibido datos de ejemplo/muestras.\n" .
-            "4) Rangos dinámicos: calcula yearMin/yearMax y min/max de valores.\n" .
-            "5) Prohibido: eval(), import(), fetch(), XHR, CSS externo.\n" .
-            "6) Respuesta: devuelve EXCLUSIVAMENTE el código entre:\n" .
+            "3) Rangos dinámicos: calcula yearMin/yearMax y min/max de valores.\n" .
+            "4) Prohibido: eval(), import(), fetch(), XHR, CSS externo.\n" .
+            "5) Respuesta: devuelve EXCLUSIVAMENTE el código entre:\n" .
             "-----BEGIN_P5JS-----\n" .
             "...AQUÍ VA EL CÓDIGO...\n" .
             "-----END_P5JS-----";

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -169,7 +169,7 @@ function tanviz_rest_generate( WP_REST_Request $req ) {
             'message'     => $e->getMessage(),
         ]);
         tanviz_lessons_update([
-            "Placeholders Incorrectos: reemplaza {{col.year}} y {{col.value}} por las columnas reales del CSV.",
+            "Usa las cabeceras reales del CSV en lugar de placeholders.",
             "Manejo de Errores: captura fallos al cargar CSV (URL incorrecta/archivo no disponible).",
             "Optimización: usa noLoop() para visualización estática.",
         ]);
@@ -192,7 +192,7 @@ function tanviz_rest_generate( WP_REST_Request $req ) {
             'openai_error'=> $resp['raw'] ?? '',
         ]);
         tanviz_lessons_update([
-            "Placeholders Incorrectos: reemplaza {{col.year}} y {{col.value}} por las columnas reales del CSV.",
+            "Usa las cabeceras reales del CSV en lugar de placeholders.",
             "Manejo de Errores: captura fallos al cargar CSV (URL incorrecta/archivo no disponible).",
             "Optimización: usa noLoop() para visualización estática.",
         ]);
@@ -215,11 +215,11 @@ function tanviz_rest_generate( WP_REST_Request $req ) {
             'openai_error'=> $err_txt,
         ]);
         tanviz_lessons_update([
-            "Placeholders Incorrectos: reemplaza {{col.year}} y {{col.value}} por las columnas reales del CSV.",
+            "Usa las cabeceras reales del CSV en lugar de placeholders.",
             "Manejo de Errores: captura fallos al cargar CSV (URL incorrecta/archivo no disponible).",
             "Optimización: usa noLoop() para visualización estática.",
         ]);
-        $prompt_fix = "Corrige el código p5.js basándote en los errores detectados. Debes reemplazar ÚNICAMENTE lo imprescindible y devolver el archivo COMPLETO listo para ejecutar.\n\nOBJETIVO\n- Entregar SOLO el código final p5.js entre marcadores.\n\nCONTEXTO\nERROR EN VALIDACIÓN:\n{$err_txt}\n\nCÓDIGO ACTUAL:\n{$code}\n\nREGLAS DE CORRECCIÓN (OBLIGATORIAS)\n1) Sustitución mínima: conserva intención original.\n2) Estructura p5.js: preload(), setup(), draw() y helpers usados.\n3) Mantén dataset/URLs/placeholders existentes.\n4) Prohibido eval/import/fetch/XHR y datos de ejemplo.\n\nResponde entre:\n-----BEGIN_P5JS-----\n...CÓDIGO CORREGIDO...\n-----END_P5JS-----";
+        $prompt_fix = "Corrige el código p5.js basándote en los errores detectados. Debes reemplazar ÚNICAMENTE lo imprescindible y devolver el archivo COMPLETO listo para ejecutar.\n\nOBJETIVO\n- Entregar SOLO el código final p5.js entre marcadores.\n\nCONTEXTO\nERROR EN VALIDACIÓN:\n{$err_txt}\n\nCÓDIGO ACTUAL:\n{$code}\n\nREGLAS DE CORRECCIÓN (OBLIGATORIAS)\n1) Sustitución mínima: conserva intención original.\n2) Estructura p5.js: preload(), setup(), draw() y helpers usados.\n3) Mantén dataset/URLs existentes.\n4) Prohibido eval/import/fetch/XHR y datos de ejemplo.\n\nResponde entre:\n-----BEGIN_P5JS-----\n...CÓDIGO CORREGIDO...\n-----END_P5JS-----";
 
         $retry = tanviz_openai_assistant_chat( [
             'dataset_url'    => $dataset_url,
@@ -240,7 +240,7 @@ function tanviz_rest_generate( WP_REST_Request $req ) {
                 'openai_error'=> $retry['raw'] ?? '',
             ]);
             tanviz_lessons_update([
-                "Placeholders Incorrectos: reemplaza {{col.year}} y {{col.value}} por las columnas reales del CSV.",
+                "Usa las cabeceras reales del CSV en lugar de placeholders.",
                 "Manejo de Errores: captura fallos al cargar CSV (URL incorrecta/archivo no disponible).",
                 "Optimización: usa noLoop() para visualización estática.",
             ]);
@@ -262,7 +262,7 @@ function tanviz_rest_generate( WP_REST_Request $req ) {
                 'message'     => 'Validation failed after retry ' . implode( ', ', $val['errors'] ),
             ]);
             tanviz_lessons_update([
-                "Placeholders Incorrectos: reemplaza {{col.year}} y {{col.value}} por las columnas reales del CSV.",
+                "Usa las cabeceras reales del CSV en lugar de placeholders.",
                 "Manejo de Errores: captura fallos al cargar CSV (URL incorrecta/archivo no disponible).",
                 "Optimización: usa noLoop() para visualización estática.",
             ]);
@@ -407,10 +407,10 @@ CÓDIGO ACTUAL:
 REGLAS DE CORRECCIÓN (OBLIGATORIAS)
 1) Sustitución mínima: modifica SOLO lo imprescindible para resolver el/los errores y mantener la intención original.
 2) Estructura p5.js obligatoria: incluir (según corresponda) preload(), setup(), draw() y cualquier función auxiliar usada.
-3) Mantener placeholders/datos:
+3) Mantener datos:
    - No inventar datos ni usar muestras ficticias.
-   - Respetar y reutilizar exactamente los placeholders/variables/URLs existentes (p.ej. {{DATASET_URL}}, {{col.year}}, {{col.value}}).
-4) Sin dependencias externas nuevas: no añadir librerías ni fetchs/cargas fuera de los mecanismos ya presentes/placeholders.
+   - Respetar y reutilizar exactamente las variables/URLs existentes (p.ej. dataset_url).
+4) Sin dependencias externas nuevas: no añadir librerías ni fetchs/cargas fuera de los mecanismos ya presentes.
 5) Robustez:
    - Manejo básico de errores (p.ej., verificar existencia de columnas/valores antes de acceder).
    - Evitar patrones frágiles (eval, import dinámicos, XHR no previsto).
@@ -420,13 +420,13 @@ REGLAS DE CORRECCIÓN (OBLIGATORIAS)
    - No incluir banners, encabezados, ni “```explicaciones```”. SOLO el código JS final.
 7) Compatibilidad:
    - Mantener el API esperado por el entorno (nombres de funciones/variables públicas).
-   - No cambiar nombres de placeholders ni la interfaz esperada por el sistema.
+   - No cambiar nombres de variables ni la interfaz esperada por el sistema.
 8) Performance: evitar bucles/operaciones innecesarias en draw().
 
 VALIDACIONES AUTOMÁTICAS (ANTES DE DEVOLVER EL CÓDIGO)
 - [ ] ¿Se resuelven los puntos indicados en la retroalimentación?
 - [ ] ¿El archivo es completo, ejecutable en p5.js y sin errores de sintaxis?
-- [ ] ¿Se han conservado placeholders/variables/URLs originales?
+- [ ] ¿Se han conservado variables/URLs originales?
 - [ ] ¿No hay comentarios, impresiones de consola ni texto adicional?
 - [ ] ¿Se mantiene preload/setup/draw (si aplica) y la intención original?
 
@@ -458,7 +458,7 @@ PROMPT;
             'message'     => $resp->get_error_message(),
         ]);
         tanviz_lessons_update([
-            "Placeholders Incorrectos: reemplaza {{col.year}} y {{col.value}} por las columnas reales del CSV.",
+            "Usa las cabeceras reales del CSV en lugar de placeholders.",
             "Manejo de Errores: captura fallos al cargar CSV (URL incorrecta/archivo no disponible).",
             "Optimización: usa noLoop() para visualización estática.",
         ]);
@@ -479,7 +479,7 @@ PROMPT;
             'openai_error'=> $raw,
         ]);
         tanviz_lessons_update([
-            "Placeholders Incorrectos: reemplaza {{col.year}} y {{col.value}} por las columnas reales del CSV.",
+            "Usa las cabeceras reales del CSV en lugar de placeholders.",
             "Manejo de Errores: captura fallos al cargar CSV (URL incorrecta/archivo no disponible).",
             "Optimización: usa noLoop() para visualización estática.",
         ]);
@@ -501,7 +501,7 @@ PROMPT;
             'message'     => 'No output from OpenAI',
         ]);
         tanviz_lessons_update([
-            "Placeholders Incorrectos: reemplaza {{col.year}} y {{col.value}} por las columnas reales del CSV.",
+            "Usa las cabeceras reales del CSV en lugar de placeholders.",
             "Manejo de Errores: captura fallos al cargar CSV (URL incorrecta/archivo no disponible).",
             "Optimización: usa noLoop() para visualización estática.",
         ]);

--- a/includes/utils-logging.php
+++ b/includes/utils-logging.php
@@ -83,7 +83,7 @@ add_action( 'tanviz_logs_cleanup_daily', function(){
 
 add_action( 'init', function(){
     tanviz_lessons_update([
-        "Placeholders Incorrectos: debes reemplazar '{{col.year}}' y '{{col.value}}' por los nombres reales de columnas.",
+        "Evita placeholders: usa los nombres reales de las columnas.",
         "Cálculo de Rango: verifica datos vacíos o mal formateados antes de min/max.",
         "Visualización: beginShape()/endShape() + puntos para resaltar observaciones.",
         "Manejo de Errores: captura fallos al cargar CSV (URL incorrecta / 404).",

--- a/prompts/generate_visualization.json
+++ b/prompts/generate_visualization.json
@@ -11,16 +11,6 @@
       "key": "DATASET_URL",
       "description": "URL directa al dataset en formato CSV o JSON.",
       "example": "https://raw.githubusercontent.com/usuario/datasets/main/temperaturas.csv"
-    },
-    {
-      "key": "col.year",
-      "description": "Nombre genérico de la columna que contiene los años.",
-      "example": "year"
-    },
-    {
-      "key": "col.value",
-      "description": "Nombre genérico de la columna que contiene los valores numéricos de la serie temporal.",
-      "example": "value"
     }
   ],
   "sections": {
@@ -32,13 +22,13 @@
     "inputs": {
       "prompt_usuario": "{{PROMPT_USUARIO}}",
       "dataset_url": "{{DATASET_URL}}",
-      "dataset_notes": "El dataset puede ser CSV o JSON. Usa los placeholders existentes, por ejemplo: {{col.year}}, {{col.value}}."
+      "dataset_notes": "El dataset puede ser CSV o JSON. Utiliza los nombres reales de las columnas."
     },
     "rules": [
       "Estructura p5.js: incluir (según corresponda) preload(), setup(), draw(), windowResized() y funciones auxiliares como drawGenerativeVisualization().",
       "Declarar todas las variables de estado compartidas (table, years, values, minValue, maxValue y cualquier otra usada en varias funciones) una sola vez en el ámbito global.",
       "Carga de datos: usar exclusivamente funciones de p5.js en preload() (loadTable, loadJSON) para {{DATASET_URL}}. No inventar datos ni columnas.",
-      "Procesamiento: usar {{col.year}}, {{col.value}} como referencia genérica para acceder a columnas, detectando el índice por nombre (insensible a mayúsculas/minúsculas).",
+      "Procesamiento: acceder a las columnas utilizando sus nombres reales, detectando el índice por nombre (insensible a mayúsculas/minúsculas).",
       "Rango dinámico: calcular minValue y maxValue a partir de los datos cargados.",
       "Visualización: usar map(), min(), max(), background(), stroke(), fill() y otras funciones de p5.js para representar los datos de forma creativa.",
       "Compatibilidad: el código debe ser autónomo y ejecutable directamente en un entorno p5.js sin dependencias externas.",


### PR DESCRIPTION
## Summary
- Ensure newline characters render properly in admin code output and parsing
- Drop dataset placeholder instructions in prompts and REST guidance
- Update lessons and logging to encourage using real dataset headers

## Testing
- `php -l includes/openai.php`
- `php -l includes/rest.php`
- `php -l includes/utils-logging.php`
- `node --check assets/admin.js`
- `jq . prompts/generate_visualization.json`


------
https://chatgpt.com/codex/tasks/task_e_68a16a5974b0833288f446b1944104f4